### PR TITLE
Hotfix votable description

### DIFF
--- a/daiquiri/core/generators.py
+++ b/daiquiri/core/generators.py
@@ -99,10 +99,8 @@ def generate_votable(generator, fields, infos=[], links=[], services=[], table=N
         if 'arraysize' in field:
             if field.get('datatype') == 'char' and field['arraysize'] is None:
                 attrs.append('arraysize="*"')
-        """
             elif field['arraysize']:
                 attrs.append('arraysize="{}"'.format(field['arraysize']))
-        """
 
         if 'datatype' in field:
             if field['datatype'] in [

--- a/daiquiri/core/generators.py
+++ b/daiquiri/core/generators.py
@@ -1,4 +1,3 @@
-import re
 import csv
 import io
 import logging
@@ -140,7 +139,7 @@ def generate_votable(generator, fields, infos=[], links=[], services=[], table=N
             if description:
                 yield """
                 <FIELD {}> <DESCRIPTION>{}</DESCRIPTION> </FIELD>
-                """.format(' '.join(attrs), description)
+                """.format(' '.join(attrs), escape(description))
             else:
                 yield """
                 <FIELD {} />""".format(' '.join(attrs))


### PR DESCRIPTION
This PR fixes the description field in the generated xml votable. Previously, special characters broke the xml file. 
Additionally, the datatype `char`  in the metadata  is now again handled as a string in a votable. 