### PR TITLE
Fix pgdump parser for values containing );

### DIFF
--- a/daiquiri/core/adapter/download/base.py
+++ b/daiquiri/core/adapter/download/base.py
@@ -127,7 +127,7 @@ class BaseDownloadAdapter:
             process = subprocess.Popen(self.args, stdout=subprocess.PIPE)
 
             for line in process.stdout:
-                insert_pattern = re.compile('^INSERT INTO .*? VALUES \\((.*?)\\);')
+                insert_pattern = re.compile('^INSERT INTO .*? VALUES \\((.*?)\\);\s*$')
                 insert_result = insert_pattern.match(line.decode())
                 if insert_result:
                     line = insert_result.group(1)


### PR DESCRIPTION
Currently the pg_dump parser we are using to generate rows for the download fails (mostly silently) if the data contains );. In this case the regex match breaks too early, which leads to truncated data in the best case and errors in the worst case scenario.
The new regex ensures that ); is matched only at the end of the line, where it is expected.