### PR TITLE
Improve performance of the table trim to max_records

### DIFF
--- a/daiquiri/core/adapter/database/base.py
+++ b/daiquiri/core/adapter/database/base.py
@@ -14,8 +14,8 @@ class BaseDatabaseAdapter:
     def connection(self):
         return connections[self.database_key]
 
-    def execute(self, sql):
-        return self.connection().cursor().execute(sql)
+    def execute(self, sql, args=None):
+        return self.connection().cursor().execute(sql, args)
 
     def fetchone(self, sql, args=None, as_dict=False):
         cursor = self.connection().cursor()

--- a/daiquiri/core/adapter/database/postgres.py
+++ b/daiquiri/core/adapter/database/postgres.py
@@ -370,8 +370,14 @@ class PostgreSQLAdapter(BaseDatabaseAdapter):
             return
 
         user_table = f'{self.escape_identifier(schema_name)}.{self.escape_identifier(table_name)}'
-        query = f"""DELETE FROM  {user_table}
-            WHERE ctid NOT IN (SELECT ctid FROM {user_table} LIMIT %s);
+        query = f"""DELETE FROM {user_table} as t
+        USING (
+            SELECT ctid
+            FROM {user_table}
+            ORDER BY ctid
+            OFFSET %s
+        ) as d
+        WHERE t.ctid = d.ctid;
         """
         self.execute(query, args=[max_records,])
 

--- a/daiquiri/core/adapter/database/postgres.py
+++ b/daiquiri/core/adapter/database/postgres.py
@@ -369,14 +369,11 @@ class PostgreSQLAdapter(BaseDatabaseAdapter):
         if not self.table_exists(schema_name, table_name):
             return
 
-        query = (
-            'DELETE FROM '
-            + f'{self.escape_identifier(schema_name)}.{self.escape_identifier(table_name)} '
-            + 'WHERE ctid NOT IN (SELECT ctid FROM '
-            + f'{self.escape_identifier(schema_name)}.{self.escape_identifier(table_name)} '
-            + f'LIMIT {max_records} );'
-        )
-        self.execute(query)
+        user_table = f'{self.escape_identifier(schema_name)}.{self.escape_identifier(table_name)}'
+        query = f"""DELETE FROM  {user_table}
+            WHERE ctid NOT IN (SELECT ctid FROM {user_table} LIMIT %s);
+        """
+        self.execute(query, args=[max_records,])
 
     def table_exists(self, schema_name, table_name):
         check_query = (

--- a/daiquiri/query/tasks.py
+++ b/daiquiri/query/tasks.py
@@ -28,6 +28,7 @@ class RunQueryTask(Task):
 
         # log raised exception
         logger.error('run_query %s raised an exception (%s)', job_id, exc)
+        logger.debug('run_query %s failed with an error: %s', job_id, einfo)
 
         # set phase and error_summary of the crashed job
         job = QueryJob.objects.get(pk=job_id)


### PR DESCRIPTION
Currently, max records for asynchronous query jobs are imposed by trimming the results table to the `max_records`. The query used for it was not optimized and timed out for some tables. The new query is more performant ensuring that the query does not timeout leading to an error in the query results.