### PR TITLE
Fix tablesize after trim

### DIFF
--- a/daiquiri/core/adapter/database/base.py
+++ b/daiquiri/core/adapter/database/base.py
@@ -187,6 +187,10 @@ class BaseDatabaseAdapter:
     def fetch_size(self, schema_name, table_name):
         raise NotImplementedError()
 
+    def fetch_size_user_table(self, schema_name, table_name):
+        # overload this if the table size of the user tables must be calculated differently.
+        return self.fetch_size(schema_name, table_name)
+
     def fetch_nrows(self, schema_name, table_name):
         raise NotImplementedError()
 

--- a/daiquiri/core/adapter/database/postgres.py
+++ b/daiquiri/core/adapter/database/postgres.py
@@ -126,6 +126,8 @@ class PostgreSQLAdapter(BaseDatabaseAdapter):
         return size
 
     def fetch_size_user_table(self, schema_name, table_name):
+        if not self.table_exists(schema_name, table_name):
+            return 0
         user_table = f'{self.escape_identifier(schema_name)}.{self.escape_identifier(table_name)}'
         sql = f'SELECT sum(pg_column_size(t)) from {user_table} as t;'
         size = self.fetchone(sql)[0]

--- a/daiquiri/core/adapter/database/postgres.py
+++ b/daiquiri/core/adapter/database/postgres.py
@@ -117,13 +117,23 @@ class PostgreSQLAdapter(BaseDatabaseAdapter):
 
     def fetch_size(self, schema_name, table_name):
         sql = (
-            'SELECT pg_total_relation_size('
+            'SELECT pg_table_size('
                 + f"'{self.escape_identifier(schema_name)}.{self.escape_identifier(table_name)}'::regclass)"
         )
         size = self.fetchone(sql)[0]
 
-        logger.debug('size = %d', size)
+        logger.debug('table size = %d', size)
         return size
+
+    def fetch_size_user_table(self, schema_name, table_name):
+        user_table = f'{self.escape_identifier(schema_name)}.{self.escape_identifier(table_name)}'
+        sql = f'SELECT sum(pg_column_size(t)) from {user_table} as t;'
+        size = self.fetchone(sql)[0]
+
+        logger.debug('user table size = %d', size)
+
+        return size
+
 
     def fetch_nrows(self, schema_name, table_name):
         # fetch the size of the table using pg_total_relation_size
@@ -381,7 +391,6 @@ class PostgreSQLAdapter(BaseDatabaseAdapter):
         WHERE t.ctid = d.ctid;
         """
         cursor = self.execute(query, args=[max_records,])
-        self.execute(f'VACUUM FULL {user_table};')
         return cursor.rowcount
 
     def table_exists(self, schema_name, table_name):

--- a/daiquiri/query/tasks.py
+++ b/daiquiri/query/tasks.py
@@ -127,7 +127,7 @@ def run_database_query_task(job_id):
             # get additional information about the completed job
             if job.phase == job.PHASE_COMPLETED:
                 job.nrows = adapter.count_rows(job.schema_name, job.table_name)
-                job.size = adapter.fetch_size(job.schema_name, job.table_name)
+                job.size = adapter.fetch_size_user_table(job.schema_name, job.table_name)
 
                 # fetch the metadata for used tables
                 job.metadata['sources'] = get_job_sources(job)


### PR DESCRIPTION
Follow up from #359 

This PR fixes the issue where the size of the created tables were not calculated correctly. Especially, the size was wrong for the trimmed tables 
https://github.com/django-daiquiri/daiquiri/blob/78d19eb641919c0b82bdb92e2f1ae1cc8ef163ed/daiquiri/core/adapter/database/postgres.py#L368-L383

It is applied only to the user created tables, because the new method is executing an additional query that can take a long time for very large tables. The user tables are limited by `JOB_MAX_RECORDS` and therefore the calculations will finish in a reasonable time. 
The size of the published tables are fetched using postgres functions. There still a small fix however. Now, the `fetch_size` methods is using `pg_table_size` instead of `pg_total_relation_size`. IMHO, this reflects the size of the data better. In general, users are interested in the size of the 'downloadable' data. The indexes on the database are not included in that case.

