### PR TITLE
Fix file url in the results of a sync query

### DIFF
--- a/daiquiri/core/adapter/download/base.py
+++ b/daiquiri/core/adapter/download/base.py
@@ -66,9 +66,7 @@ class BaseDownloadAdapter:
             elif format_key == 'fits':
                 # We have to get the maximum array lengths in case there are arrays in the data
                 schema_table_name = self.get_table_name(schema_name, table_name)
-                fits_arrayinfos = self.get_arraysizes_for_fits(
-                    columns, schema_name, table_name
-                )
+                fits_arrayinfos = self.get_arraysizes_for_fits(columns, schema_name, table_name)
 
                 return generate_fits(
                     self.generate_rows(prepend=prepend),
@@ -132,18 +130,7 @@ class BaseDownloadAdapter:
                     line = insert_result.group(1)
                     reader = csv.reader([line], quotechar="'", skipinitialspace=True)
                     row = next(reader)
-
-                    if prepend:
-                        yield [
-                            (
-                                prepend[i] + cell
-                                if (i in prepend and cell != 'NULL')
-                                else cell
-                            )
-                            for i, cell in enumerate(row)
-                        ]
-                    else:
-                        yield row
+                    yield from self.prepend_row_values(row, prepend)
 
         except subprocess.CalledProcessError as e:
             logger.error('Command PIPE returned non-zero exit status: %s', e)
@@ -152,6 +139,7 @@ class BaseDownloadAdapter:
             _ = process.wait()
 
     def get_prepend(self, columns):
+        """Returns a dict with prefixes to prepend FILES_BASE_URL to file references in the data"""
         if not settings.FILES_BASE_URL:
             return {}
 
@@ -169,9 +157,22 @@ class BaseDownloadAdapter:
                     or 'meta.image' in column_ucd
                 )
             ):
-                prepend[i] = settings.FILES_BASE_URL
+                prepend[i] = Path(settings.FILES_BASE_URL)
 
         return prepend
+
+    def prepend_row_values(self, row, prepend):
+        """Prepend values in rows according to the prepend dict.
+        Used to prepend settings.FILES_BASE_URL to file references in the data,
+        based on the column UCDs.
+        """
+        if prepend:
+            yield [
+                (prepend[i] / Path(cell) if (i in prepend and cell not in ('NULL', None)) else cell)
+                for i, cell in enumerate(row)
+            ]
+        else:
+            yield row
 
     def get_table_name(self, schema_name, table_name):
         return f'{schema_name}.{table_name}'
@@ -214,7 +215,7 @@ class BaseDownloadAdapter:
                 db = DatabaseAdapter()
 
                 query = f"""
-                    SELECT MAX(array_length({column_name}, 1)) 
+                    SELECT MAX(array_length({column_name}, 1))
                     FROM "{schema_name}"."{table_name}"
                     WHERE {column_name} IS NOT NULL
                 """

--- a/daiquiri/query/models.py
+++ b/daiquiri/query/models.py
@@ -274,11 +274,30 @@ class QueryJob(Job):
         job_sources = get_job_sources(self)
 
         try:
+            # Get the column metadata and a generator for the rows, this will execute the query
             database_columns, fetch_rows = adapter.fetchall_sync(self.actual_query)
+            columns = get_columns_metadata(self, database_columns)
+            # prepend gets the FILE_BASE_URL to prepend to the file paths accordong to the UCDs.
+            prepend = DownloadAdapter().get_prepend(columns)
+
+            # We need a wrapper to actually prepend the file base url to the file paths.
+            def row_generator(prepend=None):
+                for row in fetch_rows():
+                    if prepend:
+                        yield [
+                            (
+                                prepend[i] + cell
+                                if (i in prepend and cell != 'NULL')
+                                else cell
+                            )
+                            for i, cell in enumerate(row)
+                        ]
+                    else:
+                        yield row
 
             yield from generate_votable(
-                fetch_rows(),
-                get_columns_metadata(self, database_columns),
+                row_generator(prepend),
+                columns,
                 table=download_adapter.get_table_name(self.schema_name, self.table_name),
                 infos=download_adapter.get_infos(
                     'OK', self.query, self.query_language, job_sources

--- a/daiquiri/query/models.py
+++ b/daiquiri/query/models.py
@@ -281,19 +281,11 @@ class QueryJob(Job):
             prepend = DownloadAdapter().get_prepend(columns)
 
             # We need a wrapper to actually prepend the file base url to the file paths.
+            # For async it's not required because it's handled by generate() while
+            # for sync we are using generate_votable() directly.
             def row_generator(prepend=None):
                 for row in fetch_rows():
-                    if prepend:
-                        yield [
-                            (
-                                prepend[i] + cell
-                                if (i in prepend and cell != 'NULL')
-                                else cell
-                            )
-                            for i, cell in enumerate(row)
-                        ]
-                    else:
-                        yield row
+                    yield from DownloadAdapter().prepend_row_values(row, prepend)
 
             yield from generate_votable(
                 row_generator(prepend),


### PR DESCRIPTION
For some of the columns, daiquiri constructs a full URL by prepending `FILE_BASE_URL` to the filepath in the results.
It works for the async queries, but not for the sync queries. 
Sync queries don't use the DownloadAdapter which actually contains the necessary processing utils for that. 
This PR adds some of this processing directly into the run_sync method which solves the issue.

Additionally it fixes a small but annoying issue with the trailing slash of  `FILES_BASE_URL` by using `pathlib.Path`.
