### PR TITLE
show announcement messages on top of the browser window

### DIFF
--- a/daiquiri/contact/templates/contact/announcements.html
+++ b/daiquiri/contact/templates/contact/announcements.html
@@ -1,13 +1,14 @@
 {% if announcements %}
-<div class="container">
-{% for msg in announcements %}
+    {% for msg in announcements %}
     <div
-        class="alert alert-{{ msg.announcement_type }} position-relative m-0 py-2 rounded text-center"
+        class="alert alert-{{ msg.announcement_type }} rounded-0 position-relative m-0 py-2 text-center"
         role="alert"
         data-announcement-id="{{ msg.id }}"
     >
-        <div class="d-inline-flex align-items-center pe-5">
-            {{ msg.announcement | safe }}
+        <div class="container">
+            <div class="d-inline-flex align-items-center pe-5">
+                {{ msg.announcement | safe }}
+            </div>
         </div>
 
         <button
@@ -17,8 +18,7 @@
             data-announcement-id="{{ msg.id }}"
         ></button>
     </div>
-{% endfor %}
-</div>
+    {% endfor %}
 {% endif %}
 
 <script>

--- a/daiquiri/contact/templates/contact/announcements.html
+++ b/daiquiri/contact/templates/contact/announcements.html
@@ -1,8 +1,24 @@
 {% if announcements %}
-    {% for msg in announcements %}
-    <div class="alert alert-{{ msg.announcement_type }}"
-        role="alert">
-        {{ msg.announcement | safe }}
+<div class="container">
+{% for msg in announcements %}
+    <div
+        class="alert alert-{{ msg.announcement_type }} position-relative m-0 py-2 rounded text-center"
+        role="alert"
+        data-announcement-id="{{ msg.id }}"
+    >
+        <div class="d-inline-flex align-items-center pe-5">
+            {{ msg.announcement | safe }}
+        </div>
+
+        <button
+            type="button"
+            class="btn-close close-announcement-btn position-absolute top-50 end-0 translate-middle-y me-3"
+            aria-label="Close"
+            data-announcement-id="{{ msg.id }}"
+        ></button>
     </div>
-    {% endfor %}
+{% endfor %}
+</div>
 {% endif %}
+
+<script src="/static/contact/js/announcements.js"></script>

--- a/daiquiri/contact/templates/contact/announcements.html
+++ b/daiquiri/contact/templates/contact/announcements.html
@@ -3,7 +3,7 @@
     <div
         class="alert alert-{{ msg.announcement_type }} rounded-0 position-relative m-0 py-2 text-center"
         role="alert"
-        data-announcement-id="{{ msg.id }}"
+        data-announcement-id="{{ msg.id }}-{{ msg.updated | date:'U-u' }}"
     >
         <div class="container">
             <div class="d-inline-flex align-items-center pe-5">
@@ -15,7 +15,7 @@
             type="button"
             class="btn-close close-announcement-btn position-absolute top-50 end-0 translate-middle-y me-3"
             aria-label="Close"
-            data-announcement-id="{{ msg.id }}"
+            data-announcement-id="{{ msg.id }}-{{ msg.updated | date:'U-u' }}"
         ></button>
     </div>
     {% endfor %}
@@ -28,10 +28,8 @@
 
     for (let i = 0; i < sessionStorage.length; i++) {
         const key = sessionStorage.key(i);
-
         if (key.startsWith('announcementDismissed_')) {
             const id = key.replace('announcementDismissed_', '');
-
             css += `
                 [data-announcement-id="${id}"] {
                     display: none !important;
@@ -39,23 +37,17 @@
             `;
         }
     }
-
     style.innerHTML = css;
     document.head.appendChild(style);
 })();
 
 document.addEventListener("DOMContentLoaded", function () {
-
     const closeButtons = document.querySelectorAll('.close-announcement-btn');
 
     closeButtons.forEach(btn => {
-
         const id = btn.dataset.announcementId;
-
         btn.addEventListener('click', function () {
-
             sessionStorage.setItem(`announcementDismissed_${id}`, 'true');
-
             document
                 .querySelectorAll(`[data-announcement-id="${id}"]`)
                 .forEach(el => el.remove());

--- a/daiquiri/contact/templates/contact/announcements.html
+++ b/daiquiri/contact/templates/contact/announcements.html
@@ -21,4 +21,46 @@
 </div>
 {% endif %}
 
-<script src="/static/contact/js/announcements.js"></script>
+<script>
+(function () {
+    const style = document.createElement('style');
+    let css = '';
+
+    for (let i = 0; i < sessionStorage.length; i++) {
+        const key = sessionStorage.key(i);
+
+        if (key.startsWith('announcementDismissed_')) {
+            const id = key.replace('announcementDismissed_', '');
+
+            css += `
+                [data-announcement-id="${id}"] {
+                    display: none !important;
+                }
+            `;
+        }
+    }
+
+    style.innerHTML = css;
+    document.head.appendChild(style);
+})();
+
+document.addEventListener("DOMContentLoaded", function () {
+
+    const closeButtons = document.querySelectorAll('.close-announcement-btn');
+
+    closeButtons.forEach(btn => {
+
+        const id = btn.dataset.announcementId;
+
+        btn.addEventListener('click', function () {
+
+            sessionStorage.setItem(`announcementDismissed_${id}`, 'true');
+
+            document
+                .querySelectorAll(`[data-announcement-id="${id}"]`)
+                .forEach(el => el.remove());
+        });
+    });
+});
+
+</script>

--- a/daiquiri/core/templates/core/base.html
+++ b/daiquiri/core/templates/core/base.html
@@ -1,4 +1,5 @@
 {% load static %}<!DOCTYPE html>
+{% load announcement_tags %}
 <html>
 
 <head>
@@ -18,6 +19,8 @@
 </head>
 
 <body>
+
+{% show_announcements %}
 
 {% include 'core/base_navigation.html' %}
 


### PR DESCRIPTION
Closes #398 

## What changed

Announcement messages are now put in `core/base.html`, above the navigation.
This means they are shown for all apps using the base template, without adding
the announcement tag to every app or CMS document.

The announcement card uses the full browser width, while the message itself is
kept as wide as the regular page content.

## Dismissing messages

Announcements can be closed for the current browser session. If an
announcement is updated later, it is shown again even if the previous version
was dismissed.

## Updating existing apps

Apps already extending `core/base.html` do not need any new integration. If an
app still adds `{% load announcement_tags %}` and `{% show_announcements %}`
manually, remove these calls; otherwise the announcement will be rendered
twice.