### PR TITLE
Fix ivoa tables

### DIFF
--- a/daiquiri/datalink/constants.py
+++ b/daiquiri/datalink/constants.py
@@ -3,21 +3,10 @@ DATALINK_TABLE = {
     'name': 'datalink',
     'description': 'The table of datalinks for the service',
     'order': 4,
-    'access_level': 'PUBLIC',
-    'metadata_access_level': 'PUBLIC'
+    'access_level': 'PRIVATE',
+    'metadata_access_level': 'PRIVATE'
 }
 DATALINK_FIELDS = [
-    {
-        'name': 'datalink_id',
-        'order': 0,
-        'description': 'Internal datalink identifier',
-        'ucd': 'meta.id;meta.main',
-        'datatype': 'int',
-        'arraysize': None,
-        'std': True,
-        'access_level': 'PUBLIC',
-        'metadata_access_level': 'PUBLIC'
-    },
     {
         'name': 'ID',
         'order': 1,

--- a/daiquiri/datalink/utils.py
+++ b/daiquiri/datalink/utils.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.db.utils import ProgrammingError
+
 from .adapter import DatalinkAdapter
 from .models import Datalink
 
@@ -19,8 +21,11 @@ def update_links(resource_type, resource):
         for link in links:
             datalinks.append(Datalink(**link))
 
-        Datalink.objects.filter(ID=identifier).delete()
-        Datalink.objects.bulk_create(datalinks)
+        try:
+            Datalink.objects.filter(ID=identifier).delete()
+            Datalink.objects.bulk_create(datalinks)
+        except ProgrammingError:
+            pass
 
 
 def delete_links(resource_type, resource):
@@ -31,4 +36,7 @@ def delete_links(resource_type, resource):
     if resource_type in adapter.resource_types:
         identifier = adapter.get_identifier(resource_type, resource)
 
-        Datalink.objects.filter(ID=identifier).delete()
+        try:
+            Datalink.objects.filter(ID=identifier).delete()
+        except ProgrammingError:
+            pass

--- a/daiquiri/oai/adapter.py
+++ b/daiquiri/oai/adapter.py
@@ -248,9 +248,12 @@ class DatalinkOaiAdapterMixin:
             ],
             'related_identifiers': [],
         }
+
         for _, access_url, _, _, description, semantics, content_type, content_length in rows:
             # doi is a custom datalink semantic which means that it will contain the full URL to the description
             # hence, only the end of the semantics string should be checked for #doi
+            if semantics is None:
+                continue
             if semantics.endswith('#doi'):
                 datalink['doi'] = get_doi(access_url)
                 datalink['title'] = description

--- a/daiquiri/oai/utils.py
+++ b/daiquiri/oai/utils.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.db.utils import ProgrammingError
 
 from daiquiri.core.utils import import_class
 
@@ -37,6 +38,8 @@ def update_records(resource_type, resource):
                     record = Record.objects.get(identifier=identifier, metadata_prefix=metadata_prefix)
                 except Record.DoesNotExist:
                     record = Record(identifier=identifier, metadata_prefix=metadata_prefix)
+                except ProgrammingError:
+                    return
 
                 record.datestamp = datestamp
                 record.set_spec = set_spec
@@ -67,4 +70,6 @@ def delete_records(resource_type, resource):
                 record.deleted = True
                 record.save()
             except Record.DoesNotExist:
+                pass
+            except ProgrammingError:
                 pass

--- a/daiquiri/tap/utils.py
+++ b/daiquiri/tap/utils.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db.utils import ProgrammingError
 
 from daiquiri.core.constants import ACCESS_LEVEL_INTERNAL, ACCESS_LEVEL_PUBLIC
 
@@ -12,16 +13,20 @@ def check_tap_visibility(obj):
     #   (a) PUBLIC or INTERNAL if QUERY_ANONYMOUS is True
     # or
     #   (b) INTERNAL if QUERY_ANONYMOUS is False
-    return (obj.metadata_access_level == ACCESS_LEVEL_PUBLIC) or \
-        (obj.metadata_access_level == ACCESS_LEVEL_INTERNAL and not settings.QUERY_ANONYMOUS)
+    return (obj.metadata_access_level == ACCESS_LEVEL_PUBLIC) or (
+        obj.metadata_access_level == ACCESS_LEVEL_INTERNAL and not settings.QUERY_ANONYMOUS
+    )
 
 
 def update_schema(schema):
-    '''
+    """
     Update or create the schema in the TAP_SCHEMA.
-    '''
+    """
     if check_tap_visibility(schema):
-        tap_schema, created = TapSchema.objects.get_or_create(pk=schema.id)
+        try:
+            tap_schema, created = TapSchema.objects.get_or_create(pk=schema.id)
+        except ProgrammingError:
+            return
 
         tap_schema.schema_name = schema.name
         tap_schema.utype = None
@@ -47,31 +52,37 @@ def update_schema(schema):
 
         except TapSchema.DoesNotExist:
             pass
+        except ProgrammingError:
+            return
 
 
 def delete_schema(schema):
-    '''
+    """
     Remove the schema from the TAP_SCHEMA (if it exists).
-    '''
+    """
     try:
-        TapSchema.objects.get(pk=schema.id).delete()
-    except TapSchema.DoesNotExist:
+        TapSchema.objects.filter(pk=schema.id).delete()
+    except ProgrammingError:
         pass
 
 
 def update_table(table):
-    '''
+    """
     Update or create the table in the TAP_SCHEMA.
-    '''
+    """
 
     # get the schema from the TAP_SCHEMA
     try:
         tap_schema = TapSchema.objects.get(pk=table.schema.id)
     except TapSchema.DoesNotExist:
         tap_schema = None
+    except ProgrammingError:
+        return
 
     if check_tap_visibility(table) and tap_schema:
-        tap_table, created = TapTable.objects.get_or_create(pk=table.id, defaults={'schema': tap_schema})
+        tap_table, created = TapTable.objects.get_or_create(
+            pk=table.id, defaults={'schema': tap_schema}
+        )
 
         tap_table.schema_name = str(table.schema)
         tap_table.table_name = str(table.schema) + '.' + str(table.name)
@@ -100,19 +111,19 @@ def update_table(table):
 
 
 def delete_table(table):
-    '''
+    """
     Remove the table from the TAP_SCHEMA (if it exists).
-    '''
+    """
     try:
-        TapTable.objects.get(pk=table.id).delete()
-    except TapTable.DoesNotExist:
+        TapTable.objects.filter(pk=table.id).delete()
+    except ProgrammingError:
         pass
 
 
 def update_column(column):
-    '''
+    """
     Update or create the column in the TAP_SCHEMA.
-    '''
+    """
     if settings.METADATA_COLUMN_PERMISSIONS:
         tap_visibility = check_tap_visibility(column)
     else:
@@ -123,6 +134,10 @@ def update_column(column):
         tap_table = TapTable.objects.get(pk=column.table.id)
     except TapTable.DoesNotExist:
         tap_table = None
+    # if TAP_SCHEMA doesn't exists do nothing
+    except ProgrammingError:
+        return
+
 
     if tap_visibility and tap_table:
         try:
@@ -156,16 +171,16 @@ def update_column(column):
     else:
         # remove the column from the TAP_SCHEMA (if it exists)
         try:
-            TapColumn.objects.get(pk=column.id).delete()
-        except TapColumn.DoesNotExist:
+            TapColumn.objects.filter(pk=column.id).delete()
+        except ProgrammingError:
             pass
 
 
 def delete_column(column):
-    '''
+    """
     Remove the column from the TAP_SCHEMA (if it exists).
-    '''
+    """
     try:
-        TapColumn.objects.get(pk=column.id).delete()
-    except TapColumn.DoesNotExist:
+        TapColumn.objects.filter(pk=column.id).delete()
+    except ProgrammingError:
         pass


### PR DESCRIPTION
This PR makes the metadata sync (update/delete/create) more forgiving when the IVOA tables, such as TAP_SCHEMA.* or OAI_SCHEMA.* are not present.

  - Makes the generated datalink metadata table private.
  - Removes the obsolete datalink_id metadata field.
  - Skips TAP_SCHEMA, OAI, and datalink sync work when the corresponding tables are missing.
