### PR TITLE
Fix max_records for conesearch

### DIFF
--- a/daiquiri/conesearch/adapter.py
+++ b/daiquiri/conesearch/adapter.py
@@ -164,7 +164,9 @@ WHERE 1=CONTAINS(POINT({ra_column}, {dec_column}), CIRCLE(POINT({RA}, {DEC}), {S
             raise NotFound(errors)
 
     def stream(self):
+        adapter = DatabaseAdapter()
+        _, generator = adapter.fetchall_sync(self.sql, self.args)
         return FileResponse(
-            generate_votable(DatabaseAdapter().fetchall(self.sql, self.args), self.columns),
+            generate_votable(generator(), self.columns, max_records=self.max_records),
             content_type='application/xml',
         )

--- a/daiquiri/conesearch/tests/adapter.py
+++ b/daiquiri/conesearch/tests/adapter.py
@@ -1,0 +1,13 @@
+from daiquiri.conesearch.adapter import BaseConeSearchAdapter
+
+
+class BoxConeSearchAdapter(BaseConeSearchAdapter):
+    sql_pattern = """
+SELECT {columns}
+FROM {schema}.{table}
+WHERE {ra_column} BETWEEN {RA} - {SR} AND {RA} + {SR}
+AND {dec_column} BETWEEN {DEC} - {SR} AND {DEC} + {SR}
+"""
+
+    def get_query_language(self, data):
+        return 'postgresql'

--- a/daiquiri/conesearch/tests/test_viewsets.py
+++ b/daiquiri/conesearch/tests/test_viewsets.py
@@ -1,0 +1,94 @@
+import xml.etree.ElementTree as et
+
+from django.test import override_settings
+from django.urls import reverse
+from django.utils.http import urlencode
+
+from daiquiri.conesearch.tests.adapter import BoxConeSearchAdapter
+
+
+url_names = {
+    'search': 'conesearch:search'
+}
+
+adapter = 'daiquiri.conesearch.tests.adapter.BoxConeSearchAdapter'
+
+resource = 'daiquiri_data_obs.stars'
+
+resources = {
+    resource: {
+        'schema_name': 'daiquiri_data_obs',
+        'table_name': 'stars',
+        'column_names': ['id', 'ra', 'dec'],
+        'coordinates_columns': {
+            'RA': 'ra',
+            'DEC': 'dec'
+        },
+    }
+}
+
+query = {
+    'RA': 145.7,
+    'DEC': -60.3,
+    'SR': 1
+}
+
+votable_ns = '{http://www.ivoa.net/xml/VOTable/v1.3}'
+
+
+@override_settings(
+    CONESEARCH_ADAPTER=adapter,
+    CONESEARCH_RESOURCES=resources
+)
+def test_search(db, client):
+    '''
+    A cone-search request returns a VOTable.
+    '''
+    client.login(username='user', password='user')
+
+    url = reverse(url_names['search'], args=[resource]) + '?' + urlencode(query)
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@override_settings(
+    CONESEARCH_ADAPTER=adapter,
+    CONESEARCH_ANONYMOUS=True,
+    CONESEARCH_RESOURCES=resources
+)
+def test_search_anonymous(db, client):
+    '''
+    A cone-search request can be performed anonymously when enabled.
+    '''
+    url = reverse(url_names['search'], args=[resource]) + '?' + urlencode(query)
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@override_settings(
+    CONESEARCH_ADAPTER=adapter,
+    CONESEARCH_RESOURCES=resources
+)
+def test_search_overflow(db, client, mocker):
+    '''
+    A truncated cone-search response reports an overflow.
+    '''
+    mocker.patch.object(BoxConeSearchAdapter, 'max_records', 1)
+
+    client.login(username='user', password='user')
+
+    url = reverse(url_names['search'], args=[resource]) + '?' + urlencode(query)
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+    root = et.fromstring(b''.join(response.streaming_content))
+    rows = root.findall(f'.//{votable_ns}TR')
+    overflow = root.find(
+        f'.//{votable_ns}INFO[@name="QUERY_STATUS"][@value="OVERFLOW"]'
+    )
+
+    assert len(rows) == 1
+    assert overflow is not None

--- a/daiquiri/core/adapter/database/base.py
+++ b/daiquiri/core/adapter/database/base.py
@@ -54,7 +54,7 @@ class BaseDatabaseAdapter:
         else:
             return cursor.fetchall()
 
-    def fetchall_sync(self, sql):
+    def fetchall_sync(self, sql, args=None):
         raise NotImplementedError()
 
     def fetch_pid(self):

--- a/daiquiri/core/adapter/database/postgres.py
+++ b/daiquiri/core/adapter/database/postgres.py
@@ -71,9 +71,12 @@ class PostgreSQLAdapter(BaseDatabaseAdapter):
     def escape_string(self, string):
         return f"'{string}'"
 
-    def fetchall_sync(self, sql):
+    def fetchall_sync(self, sql, args=None):
         cursor = self.connection().cursor()
-        cursor.execute(sql)
+        if args:
+            cursor.execute(sql, args)
+        else:
+            cursor.execute(sql)
 
         while cursor.description is None and cursor.nextset():
             pass


### PR DESCRIPTION
`CONESEARCH_MAX_RECORDS` was already advertised as `maxRecords` in the Cone Search capabilities, but it did not limit the response.

  This change applies the configured limit and adds `QUERY_STATUS=OVERFLOW` to the VOTable when more records are available. Additionally, I added some basic tests for Cone Search.
