### PR TITLE
Fix upload for the async jobs

### DIFF
--- a/daiquiri/core/utils.py
+++ b/daiquiri/core/utils.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from collections import defaultdict
+from copy import copy
 from datetime import datetime
 from urllib.parse import urlparse
 from xml.dom import minidom
@@ -240,7 +241,7 @@ def markdown(md):
 
 
 def make_query_dict_upper_case(input_dict):
-    output_dict = input_dict.copy()
+    output_dict = copy(input_dict)
 
     for key in input_dict.keys():
         if key.upper() != key:


### PR DESCRIPTION
This PR fixes an error that occurs when handling table uploads in TAP requests.
```bash
ERROR: Internal Server Error: /tap/async
Traceback (most recent call last):
  File "/home/dq/.venv/lib/python3.13/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/home/dq/.venv/lib/python3.13/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/dq/.venv/lib/python3.13/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "/home/dq/.venv/lib/python3.13/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dq/.venv/lib/python3.13/site-packages/rest_framework/views.py", line 515, in dispatch
    response = self.handle_exception(exc)
  File "/home/dq/.venv/lib/python3.13/site-packages/rest_framework/views.py", line 475, in handle_exception
    self.raise_uncaught_exception(exc)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/home/dq/.venv/lib/python3.13/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
    raise exc
  File "/home/dq/.venv/lib/python3.13/site-packages/rest_framework/views.py", line 512, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/dq/source/daiquiri/jobs/viewsets.py", line 144, in create
    serializer = self.get_serializer(data=request.data)
  File "/home/dq/.venv/lib/python3.13/site-packages/rest_framework/generics.py", line 114, in get_serializer
    return serializer_class(*args, **kwargs)
  File "/home/dq/source/daiquiri/core/serializers.py", line 48, in __init__
    kwargs['data'] = make_query_dict_upper_case(kwargs['data'])
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/dq/source/daiquiri/core/utils.py", line 243, in make_query_dict_upper_case
    output_dict = input_dict.copy()
  File "/home/dq/.venv/lib/python3.13/site-packages/django/http/request.py", line 696, in copy
    return self.__deepcopy__({})
           ~~~~~~~~~~~~~~~~~^^^^
  File "/home/dq/.venv/lib/python3.13/site-packages/django/http/request.py", line 657, in __deepcopy__
    result.setlist(copy.deepcopy(key, memo), copy.deepcopy(value, memo))
                                             ~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/copy.py", line 137, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.13/copy.py", line 197, in _deepcopy_list
    append(deepcopy(a, memo))
           ~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3.13/copy.py", line 163, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.13/copy.py", line 260, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib/python3.13/copy.py", line 137, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.13/copy.py", line 222, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/copy.py", line 163, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.13/copy.py", line 260, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib/python3.13/copy.py", line 137, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.13/copy.py", line 222, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/copy.py", line 152, in deepcopy
    rv = reductor(4)
TypeError: cannot pickle 'BufferedRandom' instances

```